### PR TITLE
Literal special form

### DIFF
--- a/src/com/reasonr/scriptjure.clj
+++ b/src/com/reasonr/scriptjure.clj
@@ -78,7 +78,7 @@
 (defmethod emit :default [expr]
   (str expr))
 
-(def special-forms (set ['var '. '.. 'if 'funcall 'fn 'quote 'set! 'return 'delete 'new 'do 'aget 'while 'doseq 'str 'inc! 'dec! 'dec 'inc 'defined? 'and 'or '?]))
+(def special-forms (set ['var '. '.. 'if 'funcall 'fn 'quote 'set! 'return 'delete 'new 'do 'aget 'while 'doseq 'str 'inc! 'dec! 'dec 'inc 'defined? 'and 'or '? 'literal]))
 
 (def prefix-unary-operators (set ['!]))
 
@@ -219,6 +219,9 @@
          (emit (list* 'doseq more body))
          (emit-do body))
        "\n }"))
+
+(defmethod emit-special 'literal [type [& literal-string]]
+  (apply str literal-string))
 
 (defn emit-var-declarations []
   (when-not (empty? @var-declarations)


### PR DESCRIPTION
I'm after adding a literal special form, to allow insertion of literal strings into the compiled javascript. I don't believe there is a way of doing this at the moment using scriptjure.

Example of usage:

```
(js (var regex (literal "/[^\w ]+/g")))
```

Will compile into this javascript code:

```
var regex = /[^\w ]+/g;
```
