### PR TITLE
Chainable aget

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -119,10 +119,15 @@ Results in a new statement. The first argument is the object. All remaining item
     => "new google.visualization.Query(url)"
 
 **aget**
-    (aget obj index)
+    (aget obj & indexes)
 
     (js (aget foo 42))
     => "foo[42]"
+
+Array access can also be chained.  This is helpful not only for multidimensional arrays, but for reaching deep into objects using a series of keys (similar to `clojure.core/get-in`)
+
+    (js (aget foo bar "baz"))
+    => "foo[bar][\"baz\"]"
 
 To set an array, combine with set!
  

--- a/README.markdown
+++ b/README.markdown
@@ -114,6 +114,7 @@ Takes one argument, results in a delete statement
     (new Obj & args)
 
 Results in a new statement. The first argument is the object. All remaining items in the list are treated as arguments to the contructor.
+
     (js (new google.visualization.Query url)) 
     => "new google.visualization.Query(url)"
 

--- a/src/com/reasonr/scriptjure.clj
+++ b/src/com/reasonr/scriptjure.clj
@@ -174,8 +174,10 @@
 (defmethod emit-special 'new [type [new class & args]]
   (str "new " (emit class) (comma-list (map emit args))))
 
-(defmethod emit-special 'aget [type [aget var idx]]
-  (str (emit var) "[" (emit idx) "]"))
+(defmethod emit-special 'aget [type [aget var & idxs]]
+  (apply str
+         (emit var)
+         (interleave (repeat "[") (map emit idxs) (repeat "]"))))
 
 (defmethod emit-special 'inc! [type [inc var]]
   (str (emit var) "++"))

--- a/test/test_scriptjure.clj
+++ b/test/test_scriptjure.clj
@@ -86,7 +86,9 @@
   (is (= (js [1 "2" :foo]) "[1, \"2\", foo]")))
 
 (deftest test-aget
-  (is (= (js (aget foo 2)) "foo[2]")))
+  (is (= (js (aget foo 2)) "foo[2]"))
+  (is (= (js (aget foo bar baz) "foo[bar][baz]")))
+  (is (= (js (aget foo "bar" "baz") "foo[\"bar\"][\"baz\"]"))))
 
 (deftest test-map
   (is (= (strip-whitespace (js {:packages ["columnchart"]})) "{packages: [\"columnchart\"]}")))


### PR DESCRIPTION
I tweaked aget to accept multiple keys, allowing you to generate Javascript code like this:

```
foo[bar][baz]
```

using Scriptjure code like this:

```
(aget foo bar baz)
```

instead of this:

```
(aget (aget foo bar) baz)
```

It's backward compatible with the current aget behavior, so it won't break anyone's code.  I added tests for this new functionality, as well as documentation in the README file.

An alternative approach might be to create a new special form: aget-in.  Like clojure.core/get-in, aget-in would accept a vector of keys (as opposed to a vararg with '&').  This might be better in the long run, as it would allow you to easily create key sequences programmatically.  It's also closer to Clojure's approach, which is always nice.  If you like that approach better (and the idea of this patch in general), I'll make the necessary changes and resubmit.

Thanks,
Chris
