### PR TITLE
Add defjsmacro to make generating JS cleaner

### DIFF
--- a/src/com/reasonr/scriptjure.clj
+++ b/src/com/reasonr/scriptjure.clj
@@ -345,18 +345,26 @@
 ;; Custom forms
 ;;**********************************************************
 
+(defonce custom-forms (atom {}))
+
+(defmacro defjsmacro [nme params & body]
+  `(do
+     (defn ~nme ~params
+       (js*
+         ~@body))
+     (add-custom-form '~nme ~nme)))
+
 (defn add-custom-form [form func]
   (swap! custom-forms assoc form func))
 
 (defn get-custom [form]
   (get @custom-forms form))
 
+(defn custom-form? [expr]
+  (get-custom expr))
+
 (defn emit-custom [head expr]
   (when-let [func (get-custom head)]
     (let [v (apply func (next expr))]
       (emit v))))
 
-(defonce custom-forms (atom {}))
-
-(defn custom-form? [expr]
-  (get @custom-forms expr))

--- a/test/test_scriptjure.clj
+++ b/test/test_scriptjure.clj
@@ -8,9 +8,6 @@
   [str]
   (str/trim (str/replace (str/replace str #"\n" " ") #"[ ]+" " ")))
 
-(defn prn-hw [n z]
- (js* (alert (str "hello world " (clj n)))))
-
 (deftest number-literal
   (is (= (js 42) "42"))
   (is (= (js 1/2) "0.5")))
@@ -169,11 +166,13 @@
   (is (= (strip-whitespace(js (set! x 1 y 2)))
          "x = 1; y = 2;")))
 
+(defjsmacro prn-hw [n]
+ (alert (str "hello world " (clj n))))
+
 (deftest custom-form-add
-         (add-custom-form 'prn-hw prn-hw))
-         (is (contains? @custom-forms 'prn-hw))
+         (is (get-custom 'prn-hw)))
 
 (deftest custom-form-use
-         (is (= (js (prn-hw "chris"))) "alert(\"hello world chris\")"))
+         (is (= (js (prn-hw "custom"))) "alert(\"hello world custom\")"))
 
 (run-tests)

--- a/test/test_scriptjure.clj
+++ b/test/test_scriptjure.clj
@@ -7,7 +7,10 @@
   "strip extraneous whitespace so tests don't fail because of differences in whitespace"
   [str]
   (str/trim (str/replace (str/replace str #"\n" " ") #"[ ]+" " ")))
-  
+
+(defn prn-hw [n z]
+ (js* (alert (str "hello world " (clj n)))))
+
 (deftest number-literal
   (is (= (js 42) "42"))
   (is (= (js 1/2) "0.5")))
@@ -165,5 +168,12 @@
          "x = 1;"))
   (is (= (strip-whitespace(js (set! x 1 y 2)))
          "x = 1; y = 2;")))
+
+(deftest custom-form-add
+         (add-custom-form 'prn-hw prn-hw))
+         (is (contains? @custom-forms 'prn-hw))
+
+(deftest custom-form-use
+         (is (= (js (prn-hw "chris"))) "alert(\"hello world chris\")"))
 
 (run-tests)


### PR DESCRIPTION
I've added in the notion of custom forms that can be created using defjsmacro. This allows for the use of clojure generated JS without having to wrap every single call in (clj). This makes a huge difference when you might be doing a bunch of nested calls to clj functions.
