### PR TITLE
JS macros test fix and readme updates

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -212,7 +212,7 @@ You can create custom JS Macros using `scriptjure/defjsmacro`:
 (js (on-ready (alert "hello"))) 
 
 => "$(document).ready(function() {
-        alert("hello");
+        alert(\"hello\");
     })"
 ```
 Any time you want to evaluate a clojure variable in your macro, simply wrap it in a `(clj)` call:

--- a/README.markdown
+++ b/README.markdown
@@ -201,6 +201,31 @@ If you want to pass a js form from one clojure function to another, use js*
 
 `cljs` and `cljs*` are shortcuts for `(js (clj ...))` and `(js* (clj ..))` respectively. Note that both only take one form. 
 
+JS Macros
+=======
+You can create custom JS Macros using `scriptjure/defjsmacro`:
+
+```clojure
+(defjsmacro on-ready [& body]
+    (.ready ($ document) (clj (list* (concat '(fn []) body)))))
+
+(js (on-ready (alert "hello"))) 
+
+=> "$(document).ready(function() {
+        alert("hello");
+    })"
+```
+Any time you want to evaluate a clojure variable in your macro, simply wrap it in a `(clj)` call:
+
+```clojure
+(defjsmacro custom-alert [person]
+ (alert (str "hello " (clj person))))
+
+(js (custom-alert "Joe"))
+
+=> "alert(\"hello \" + \"Joe\")"
+```
+
 License
 =======
 Scriptjure is licensed under the EPL, the same as Clojure core. See epl-v10.html in the root directory for more information.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject scriptjure "0.1.22"
+(defproject com.ibdknox.scriptjure/scriptjure "0.1.23"
   :description "a clojure DSL for generating javascript"
   :url "http://github.com/arohner/scriptjure"
   :dependencies [[org.clojure/clojure "1.2.0"]])

--- a/test/test_scriptjure.clj
+++ b/test/test_scriptjure.clj
@@ -173,6 +173,6 @@
          (is (get-custom 'prn-hw)))
 
 (deftest custom-form-use
-         (is (= (js (prn-hw "custom"))) "alert(\"hello world custom\")"))
+         (is (= (js (prn-hw "custom")) "alert(\"hello world \" + \"custom\")")))
 
 (run-tests)


### PR DESCRIPTION
These are simple, non-functional changes that correct a typo in the defjsmacro test and adds js macros to the readme.
