### PR TITLE
clojure 1.3 is stricter wrt dynamic rebinds

### DIFF
--- a/src/com/reasonr/scriptjure.clj
+++ b/src/com/reasonr/scriptjure.clj
@@ -118,7 +118,7 @@
     (str "(" (str/join (str " " (or (substitutions operator) operator) " ")
                        (map emit args)) ")")))
 
-(def var-declarations nil)
+(def ^{:dynamic true} var-declarations nil)
 
 (defmacro with-var-declarations [& body]
   `(binding [var-declarations (atom [])]


### PR DESCRIPTION
clojure 1.3 is stricter wrt dynamic rebinds, provide the right metadata for var-declarations
